### PR TITLE
Use openresolv instead of resolvconf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/wireguard/wireguard/ubuntu bionic main" >> /etc/apt/sources.list.d/wireguard.list && \
  echo resolvconf resolvconf/linkify-resolvconf boolean false | debconf-set-selections && \
  echo "REPORT_ABSENT_SYMLINK=no" >> /etc/default/resolvconf && \
- apt-get install resolvconf && \
+ apt-get install openresolv && \
  echo "**** install CoreDNS ****" && \
  COREDNS_VERSION=$(curl -sX GET "https://api.github.com/repos/coredns/coredns/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]' | awk '{print substr($1,2); }') && \


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
On a wireguard client side, the DNS IP isn't set properly when using resolvconf.
But when I use openresolv, it's work well (in my use case).
I'm in the case of #15, so I think it will fix it.

## Benefits of this PR and context:
Without this modification, I'm not able to use this docker in a client side of a Wireguard tunnel.

## How Has This Been Tested?
I have only test it on a client side. On a docker running on a Debian 10.

I haven't replicated the change on the Dockerfile.armhf and Dockerfile.aarch64 because I don't know if the issue exists in theses environment and I don't have platform for test it.
But if someone could test it, it will be nice.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
