### PR TITLE
Updating wireguard service binding example in readme

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -97,7 +97,7 @@ app_setup_block: |
     Address = 9.8.7.6/32
     DNS = 8.8.8.8
     PostUp = DROUTE=$(ip route | grep default | awk '{print $3}'); HOMENET=192.168.0.0/16; HOMENET2=10.0.0.0/8; HOMENET3=172.16.0.0/12; ip route add $HOMENET3 via $DROUTE;ip route add $HOMENET2 via $DROUTE; ip route add $HOMENET via $DROUTE;iptables -I OUTPUT -d $HOMENET -j ACCEPT;iptables -A OUTPUT -d $HOMENET2 -j ACCEPT; iptables -A OUTPUT -d $HOMENET3 -j ACCEPT;  iptables -A OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -m addrtype ! --dst-type LOCAL -j REJECT
-    PreDown = HOMENET=192.168.0.0/16; HOMENET2=10.0.0.0/8; HOMENET3=172.16.0.0/12; iptables -D OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -m addrtype ! --dst-type LOCAL -j REJECT; iptables -D OUTPUT -s $HOMENET -j ACCEPT; iptables -D OUTPUT -s $HOMENET2 -j ACCEPT; iptables -D OUTPUT -s $HOMENET3 -j ACCEPT
+    PreDown = HOMENET=192.168.0.0/16; HOMENET2=10.0.0.0/8; HOMENET3=172.16.0.0/12; ip route del $HOMENET3 via $DROUTE;ip route del $HOMENET2 via $DROUTE; ip route del $HOMENET via $DROUTE; iptables -D OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -m addrtype ! --dst-type LOCAL -j REJECT; iptables -D OUTPUT -d $HOMENET -j ACCEPT; iptables -D OUTPUT -d $HOMENET2 -j ACCEPT; iptables -D OUTPUT -d $HOMENET3 -j ACCEPT
     ```
   
 # changelog

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -102,6 +102,7 @@ app_setup_block: |
   
 # changelog
 changelogs:
+  - { date: "27.09.20:", desc: "Cleaning service binding example to have accurate PreDown script." }
   - { date: "06.08.20:", desc: "Replace resolvconf with openresolv due to dns issues when a client based on this image is connected to a server also based on this image. Add IPv6 info to readme. Display kernel version in logs." }
   - { date: "29.07.20:", desc: "Update Coredns config to detect dns loops (existing users need to delete `/config/coredns/Corefile` and restart)." }
   - { date: "27.07.20:", desc: "Update Coredns config to prevent issues with non-user-defined bridge networks (existing users need to delete `/config/coredns/Corefile` and restart)." }


### PR DESCRIPTION
We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Updating documentation in wireguard service client binding to more cleanly delete routes and iptables without forcing a container recreation.

## Benefits of this PR and context:
Users can better understand wireguard client configurations and split tunnels

## How Has This Been Tested?
Manually validated the route delete commands work as expected
