### PR TITLE
Hide output of curl when getting the server ip

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -211,7 +211,7 @@ if [ -n "$PEERS" ]; then
     PEERS="1"
   fi
   if [ -z "$SERVERURL" ] || [ "$SERVERURL" = "auto" ]; then
-    SERVERURL=$(curl icanhazip.com)
+    SERVERURL=$(curl -s icanhazip.com)
     echo "**** SERVERURL var is either not set or is set to \"auto\", setting external IP to auto detected value of $SERVERURL ****"
   else
     echo "**** External server address is set to $SERVERURL ****"


### PR DESCRIPTION
Hey,
This comit will hide the curl output from the wireguard container logs.
What appears in the logs:
```
**** Server mode is selected ****
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    14  100    14    0     0     35      0 --:--:-- --:--:-- --:--:--    35
**** SERVERURL var is either not set or is set to "auto", setting external IP to auto detected value of x.x.x.x ****
```
Thanks,
Miguel de Carvalho