### PR TITLE
Use the environment variable of SERVERPORT in templates

### DIFF
--- a/root/defaults/peer.conf
+++ b/root/defaults/peer.conf
@@ -1,7 +1,7 @@
 [Interface]
 Address = ${CLIENT_IP}
 PrivateKey = $(cat /config/${PEER_ID}/privatekey-${PEER_ID})
-ListenPort = 51820
+ListenPort = ${SERVERPORT}
 DNS = ${PEERDNS}
 
 [Peer]

--- a/root/defaults/server.conf
+++ b/root/defaults/server.conf
@@ -1,6 +1,6 @@
 [Interface]
 Address = ${INTERFACE}.1
-ListenPort = 51820
+ListenPort = ${SERVERPORT}
 PrivateKey = $(cat /config/server/privatekey-server)
 PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
The SERVERPORT environment variable was not used in the templates. Running the Server on a different port was not possible via ENV variables.

## How Has This Been Tested?
Crating new server and client containers

