### PR TITLE
Rancher specific documentation

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -117,6 +117,17 @@ app_setup_block: |
 
   Don't forget to set the necessary POSTUP and POSTDOWN rules in your client's peer conf for lan access.
 
+  ## Rancher specific usage
+
+  A number of people appear to have been having an issue when running Wireguard in Rancher where they are able to connect and a handshake is listed under `wg show`, however they're not able to access their local network, nor the internet. A fix for this appears to be to add an init container sidecar that runs a command in the main container on creation.
+  
+  To add this container through the Rancher cluster explorer UI, (after you've created the Wireguard deployment) go to its deployment page and click the kebab menu button (three vertical dots) in the top right corner and then click `add sidecar`.
+
+  In the general tab, first enter the image as `busybox`, select init container and give it a name if you wish. Next, for the command, enter `sysctl` and for the arguments, enter `-w net.ipv4.ip_forward=1`. Thirdly, select the security context tab and under privileged, select yes. Lastly, hit save in the bottom right corner and the deployment status at the top should go from active to updating. 
+  
+  You may see an error message at the bottom saying `services "wireguard" already exists`, but you can ignore it. When the deployment status returns to active, Wireguard should hopefully be running and you should be able to access your local network and the internet. You have to click cancel to exit the config page.
+  
+  Credit to u/Mr_Prometius on reddit for finding this solution, you can view the original reddit post [here](https://www.reddit.com/r/WireGuard/comments/ltibaj/wireguard_in_docker_using_rancher/)
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -125,7 +125,7 @@ app_setup_block: |
 
   In the general tab, first enter the image as `busybox`, select init container and give it a name if you wish. Next, for the command, enter `sysctl` and for the arguments, enter `-w net.ipv4.ip_forward=1`. Thirdly, select the security context tab and under privileged, select yes. Lastly, hit save in the bottom right corner and the deployment status at the top should go from active to updating. 
   
-  You may see an error message at the bottom saying `services "wireguard" already exists`, but you can ignore it. When the deployment status returns to active, Wireguard should hopefully be running and you should be able to access your local network and the internet. You have to click cancel to exit the config page.
+  You may see an error message at the bottom saying `services "wireguard" already exists`, but you can ignore it. When the deployment status returns to active, Wireguard should hopefully be running and you should be able to access your local network and the internet. You may have to click cancel to exit the config page.
   
   Credit to u/Mr_Prometius on reddit for finding this solution, you can view the original reddit post [here](https://www.reddit.com/r/WireGuard/comments/ltibaj/wireguard_in_docker_using_rancher/)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This change adds specific documentation for rancher, instructing the user on how to add a sidecar to run a command on container creation. It was pointed out that this can be done through the command field in the main container config page, however that doesn't appear to work.

## Benefits of this PR and context:
When deploying with rancher, multiple people seem to have an issue where they're able to connect to wireguard and a handshake is listed under `wg show`, however, they're not able to access their local network nor the internet. The command run in the sidecar appears to fix this.

## How Has This Been Tested?
I initially execed into the container and ran the command manually, at which point, I was immediately able to access my local network and the internet through wireguard. As a result, I added the command under the command section in the main container config page, however, this problem was still present. Due to this, I followed the instructions in the original reddit post to add a sidecar to run the command and this time the problem was fixed.
At least 3 other people have tested and found this fix to work according to the replies on the reddit post.

## Source / References:
[Original reddit post](https://www.reddit.com/r/WireGuard/comments/ltibaj/wireguard_in_docker_using_rancher/)
[Forum post this fixes](https://discourse.linuxserver.io/t/wireguard-handshake-working-but-no-internet-access/3255)