### PR TITLE
add pre-shared key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **23.04.22:** - Add pre-shared key support. Automatically added to all new peer confs generated, existing ones are left without to ensure no breaking changes.
 * **10.04.22:** - Rebase to Ubuntu Focal. Add `LOG_CONFS` env var. Remove deprecated `add-peer` command.
 * **28.10.21:** - Add site-to-site vpn support.
 * **11.02.21:** - Fix bug related to changing internal subnet and named peer confs not updating.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -121,6 +121,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "23.04.22:", desc: "Add pre-shared key support. Automatically added to all new peer confs generated, existing ones are left without to ensure no breaking changes." }
   - { date: "10.04.22:", desc: "Rebase to Ubuntu Focal. Add `LOG_CONFS` env var. Remove deprecated `add-peer` command." }
   - { date: "28.10.21:", desc: "Add site-to-site vpn support." }
   - { date: "11.02.21:", desc: "Fix bug related to changing internal subnet and named peer confs not updating." }

--- a/root/defaults/peer.conf
+++ b/root/defaults/peer.conf
@@ -1,11 +1,11 @@
 [Interface]
 Address = ${CLIENT_IP}
-PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})
 PrivateKey = $(cat /config/${PEER_ID}/privatekey-${PEER_ID})
 ListenPort = 51820
 DNS = ${PEERDNS}
 
 [Peer]
 PublicKey = $(cat /config/server/publickey-server)
+PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})
 Endpoint = ${SERVERURL}:${SERVERPORT}
 AllowedIPs = ${ALLOWEDIPS}

--- a/root/defaults/peer.conf
+++ b/root/defaults/peer.conf
@@ -1,5 +1,6 @@
 [Interface]
 Address = ${CLIENT_IP}
+PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})
 PrivateKey = $(cat /config/${PEER_ID}/privatekey-${PEER_ID})
 ListenPort = 51820
 DNS = ${PEERDNS}

--- a/root/etc/cont-init.d/40-confs
+++ b/root/etc/cont-init.d/40-confs
@@ -9,6 +9,10 @@ ln -s /config/wg0.conf /etc/wireguard/wg0.conf
   cp /defaults/server.conf /config/templates/server.conf
 [[ ! -f /config/templates/peer.conf ]] && \
   cp /defaults/peer.conf /config/templates/peer.conf
+# add preshared key to user templates (backwards compatibility)
+if ! grep -q 'PresharedKey' /config/templates/peer.conf; then
+  sed -i 's|^PrivateKey|PresharedKey = \$\(cat /config/\${PEER_ID}/presharedkey-\${PEER_ID}\)\nPrivateKey|' /config/templates/peer.conf
+fi
 
 generate_confs () {
   mkdir -p /config/server
@@ -31,6 +35,7 @@ DUDE"
     if [ ! -f "/config/${PEER_ID}/privatekey-${PEER_ID}" ]; then
       umask 077
       wg genkey | tee /config/${PEER_ID}/privatekey-${PEER_ID} | wg pubkey > /config/${PEER_ID}/publickey-${PEER_ID}
+      wg genpsk > /config/${PEER_ID}/presharedkey-${PEER_ID}
     fi
     if [ -f "/config/${PEER_ID}/${PEER_ID}.conf" ]; then
       CLIENT_IP=$(cat /config/${PEER_ID}/${PEER_ID}.conf | grep "Address" | awk '{print $NF}')
@@ -46,25 +51,43 @@ DUDE"
         fi
       done
     fi
-    eval "`printf %s`
-    cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
+    if [ -f "/config/${PEER_ID}/presharedkey-${PEER_ID}" ]; then
+      # create peer conf with presharedkey
+      eval "`printf %s`
+      cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 `cat /config/templates/peer.conf`
 DUDE"
-    SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
-    if [ -n "${!SERVER_ALLOWEDIPS}" ]; then
-      echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
+      # add peer info to server conf with presharedkey
       cat <<DUDE >> /config/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
+PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})
+DUDE
+    else
+      echo "**** Existing keys with no preshared key found for ${PEER_ID}, creating confs without preshared key for backwards compatibility ****"
+      # create peer conf without presharedkey
+      eval "`printf %s`
+      cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
+`cat /config/templates/peer.conf | sed '/PresharedKey/d'`
+DUDE"
+      # add peer info to server conf without presharedkey
+      cat <<DUDE >> /config/wg0.conf
+[Peer]
+# ${PEER_ID}
+PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
+DUDE
+    fi
+    SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
+    # add peer's allowedips to server conf
+    if [ -n "${!SERVER_ALLOWEDIPS}" ]; then
+      echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
+      cat <<DUDE >> /config/wg0.conf
 AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWEDIPS}
 
 DUDE
     else
       cat <<DUDE >> /config/wg0.conf
-[Peer]
-# ${PEER_ID}
-PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
 AllowedIPs = ${CLIENT_IP}/32
 
 DUDE

--- a/root/etc/cont-init.d/40-confs
+++ b/root/etc/cont-init.d/40-confs
@@ -11,7 +11,7 @@ ln -s /config/wg0.conf /etc/wireguard/wg0.conf
   cp /defaults/peer.conf /config/templates/peer.conf
 # add preshared key to user templates (backwards compatibility)
 if ! grep -q 'PresharedKey' /config/templates/peer.conf; then
-  sed -i 's|^PrivateKey|PresharedKey = \$\(cat /config/\${PEER_ID}/presharedkey-\${PEER_ID}\)\nPrivateKey|' /config/templates/peer.conf
+  sed -i 's|^Endpoint|PresharedKey = \$\(cat /config/\${PEER_ID}/presharedkey-\${PEER_ID}\)\nEndpoint|' /config/templates/peer.conf
 fi
 
 generate_confs () {


### PR DESCRIPTION
closes #77 

automatically adds pre-shared key to new confs generated
existing confs are left without one so as not to break existing setups (they use a pre-shared key of all zeroes as per wg default)