### PR TITLE
Add DISABLE_NAT function for disabling NAT inside the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e INTERNAL_SUBNET=10.13.13.0` | Internal subnet for the wireguard and server and peers (only change if it clashes). Used in server mode. |
 | `-e ALLOWEDIPS=0.0.0.0/0` | The IPs/Ranges that the peers will be able to reach using the VPN connection. If not specified the default value is: '0.0.0.0/0, ::0/0' This will cause ALL traffic to route through the VPN, if you want split tunneling, set this to only the IPs you would like to use the tunnel AND the ip of the server's WG ip, such as 10.13.13.1. |
 | `-e LOG_CONFS=true` | Generated QR codes will be displayed in the docker log. Set to `false` to skip log output. |
+| `-e DISABLE_NAT=true`| Disable NAT rules inside the container. |
 | `-v /config` | Contains all relevant configuration files. |
 | `-v /lib/modules` | Maps host's modules folder. |
 | `--sysctl=` | Required for client mode. |
@@ -317,6 +318,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.06.22:** - Add option for disabling NAT in container.
 * **16.05.22:** - Improve NAT handling in server mode when multiple ethernet devices are present.
 * **23.04.22:** - Add pre-shared key support. Automatically added to all new peer confs generated, existing ones are left without to ensure no breaking changes.
 * **10.04.22:** - Rebase to Ubuntu Focal. Add `LOG_CONFS` env var. Remove deprecated `add-peer` command.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ opt_param_env_vars:
   - { env_var: "INTERNAL_SUBNET", env_value: "10.13.13.0", desc: "Internal subnet for the wireguard and server and peers (only change if it clashes). Used in server mode."}
   - { env_var: "ALLOWEDIPS", env_value: "0.0.0.0/0", desc: "The IPs/Ranges that the peers will be able to reach using the VPN connection. If not specified the default value is: '0.0.0.0/0, ::0/0' This will cause ALL traffic to route through the VPN, if you want split tunneling, set this to only the IPs you would like to use the tunnel AND the ip of the server's WG ip, such as 10.13.13.1."}
   - { env_var: "LOG_CONFS", env_value: "true", desc: "Generated QR codes will be displayed in the docker log. Set to `false` to skip log output."}
+  - { env_var: "DISABLE_NAT", env_value: "true", desc: "Option for disabling NAT inside the container."}
 
 optional_block_1: false
 optional_block_1_items: ""
@@ -121,6 +122,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "03.06.22:", desc: "Added option for disabling NAT inside the container." }
   - { date: "16.05.22:", desc: "Improve NAT handling in server mode when multiple ethernet devices are present." }
   - { date: "23.04.22:", desc: "Add pre-shared key support. Automatically added to all new peer confs generated, existing ones are left without to ensure no breaking changes." }
   - { date: "10.04.22:", desc: "Rebase to Ubuntu Focal. Add `LOG_CONFS` env var. Remove deprecated `add-peer` command." }

--- a/root/defaults/server.conf
+++ b/root/defaults/server.conf
@@ -2,5 +2,5 @@
 Address = ${INTERFACE}.1
 ListenPort = 51820
 PrivateKey = $(cat /config/server/privatekey-server)
-PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth+ -j MASQUERADE
-PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth+ -j MASQUERADE
+PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT $(if [ -z $DISABLE_NAT ]; then echo '; iptables -t nat -A POSTROUTING -o eth+ -j MASQUERADE'; fi)
+PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT $(if [ -z DISABLE_NAT ]; then echo '; iptables -t nat -D POSTROUTING -o eth+ -j MASQUERADE'; fi)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This feature provides the ability for disabling NAT inside the container. It's useful when you want to manage NAT configuration directly on the docker host for different clients independently. (eg nat different clients to different external IPs)

## Benefits of this PR and context:
More deep control for your client network configuration. Can be useful in multiple scenarios.

## How Has This Been Tested?
I've built a new docker image and run it with the new env option.
Difference between startup output with this option:

> wireguard    | [#] ip -4 route add 10.13.13.2/32 dev wg0
> wireguard    | [#] iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACCEPT

and without it:

> wireguard    | [#] ip -4 route add 10.13.13.2/32 dev wg0
> wireguard    | [#] iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACCEPT ; iptables -t nat -A POSTROUTING -o eth+ -j MASQUERADE

## Source / References:
