### PR TITLE
non-alphanumeric peer names are not handled gracefully

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -121,6 +121,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "13.10.22:", desc: "Handle non-alphanumeric peer names gracefully without crashing run script." }
   - { date: "12.10.22:", desc: "Add Alpine branch." }
   - { date: "09.10.22:", desc: "Switch back to iptables-legacy due to issues on some hosts." }
   - { date: "04.10.22:", desc: "Rebase to Jammy. Upgrade to s6v3." }

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -29,7 +29,7 @@ DUDE"
     if [[ "${i}" =~ ^[0-9]+$ ]]; then
       PEER_ID="peer${i}"
     else
-      PEER_ID="peer_${i//[^[:alnum:]_-]/}"
+      PEER_ID="peer_${i//[^[:alnum:]]/}"
     fi
     mkdir -p /config/${PEER_ID}
     if [ ! -f "/config/${PEER_ID}/privatekey-${PEER_ID}" ]; then
@@ -78,10 +78,10 @@ DUDE"
 PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
 DUDE
     fi
-    SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
+    SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${PEER_ID}
     # add peer's allowedips to server conf
     if [ -n "${!SERVER_ALLOWEDIPS}" ]; then
-      echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
+      echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${PEER_ID}"
       cat <<DUDE >> /config/wg0.conf
 AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWEDIPS}
 
@@ -93,10 +93,10 @@ AllowedIPs = ${CLIENT_IP}/32
 DUDE
     fi
     if [ -z "${LOG_CONFS}" ] || [ "${LOG_CONFS}" = "true" ]; then
-      echo "PEER ${i} QR code:"
+      echo "PEER ${PEER_ID} QR code:"
       qrencode -t ansiutf8 < /config/${PEER_ID}/${PEER_ID}.conf
     else
-      echo "PEER ${i} conf and QR code png saved in /config/${PEER_ID}"
+      echo "PEER ${PEER_ID} conf and QR code png saved in /config/${PEER_ID}"
     fi
     qrencode -o /config/${PEER_ID}/${PEER_ID}.png < /config/${PEER_ID}/${PEER_ID}.conf
   done


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

 - Change-log update pushed separately.

------------------------------

## Description:

PR #134 (v1.0.20210914-ls48) changed how peer names are handled.

Prior to that release, an environment variable like the following worked:

```
- PEERS=jill-macbook,jack-chromebook,alex-nokia-g10
```

Since that release, what was then in `root/etc/cont-init.d/40-confs` and is now in
[`root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run`](https://github.com/linuxserver/docker-wireguard/blob/65e9b6148cc72a8094e9fb8de391f0f82b69b41f/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run#L81) has contained this line:

```
SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
```

When a peer name contains a character that is not allowed in a bash variable name, that statement fails with:

```
/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run: line xx: SERVER_ALLOWEDIPS_PEER_a-1: invalid variable name
```

The `run` script aborts at that point.

This problem was reported in Issue #167. The person making the report was directed to the "(alphanumeric only)" in the [documentation](https://github.com/linuxserver/docker-wireguard#parameters) and closed the issue.

Further analysis suggests there are two unresolved problems:

1. The first part of the for-loop that iterates over peer names is:

	```
	  for i in ${PEERS_ARRAY[@]}; do
	    if [[ "${i}" =~ ^[0-9]+$ ]]; then
	      PEER_ID="peer${i}"
	    else
	      PEER_ID="peer_${i//[^[:alnum:]]/}"
	    fi
	    mkdir -p /config/${PEER_ID}
	```

	The statement after the `else` permits alphanumerics, underscores
	and hyphens, so it is not consistent with the "(alphanumeric only)"
	documentation. It would be better if the code reflected the
	documentation and was expressed as:

	```
	      PEER_ID="peer_${i//[^[:alnum:]]/}"
	```

	That change has the effect of "sanitising" peer names.
	In other words:

	```
	- PEERS=jill-macbook,jack-chromebook,alex-nokia-g10
	```

	is interpreted as if it had been written as:

	```
	- PEERS=jillmacbook,jackchromebook,alexnokiag10
	```

2. In all but four places in the body of the for-loop, `PEER_ID` is used to refer to the "sanitised" version of the name. The other four places refer to `${i}` which is the raw version of the name. I was not able to construct a test case which produced inconsistencies so I don't *think* there are problems in the wild. In any event, `PEER_ID` needs to be used if the "sanitised" name is to make it through to peer creation and prevent the script from aborting.

## Benefits of this PR and context:

Together, both proposed changes mean that the revised:

```
SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${PEER_ID}
```

will always succeed (at the price of sanitising any invalid names) and will not cause the `run` script to abort.


## How Has This Been Tested?

Dockerfile:

```
FROM linuxserver/wireguard:latest
COPY --chown=root:root run /etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
```

Tested with the following variations:

```
- PEERS=3
- PEERS=iPad,iPhone,laptop
- PEERS=jill-macbook,jack-chromebook,alex-nokia-g10
```

Creates, in turn:

* peer1, peer2, peer3
* peer_iPad, peer_iPhone, peer_laptop
* peer_jillmacbook, peer_jackchromebook, peer_alexnokiag10

Does not abort on third case.

## Source / References:

PR #134 & Issue #167

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>
