### PR TITLE
reject non-alnum peer names, log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **26.10.22:** - Better handle unsupported peer names. Improve logging.
 * **12.10.22:** - Add Alpine branch. Optimize wg and coredns services.
 * **09.10.22:** - Switch back to iptables-legacy due to issues on some hosts.
 * **04.10.22:** - Rebase to Jammy. Upgrade to s6v3.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -121,6 +121,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "26.10.22:", desc: "Better handle unsupported peer names. Improve logging." }
   - { date: "12.10.22:", desc: "Add Alpine branch. Optimize wg and coredns services." }
   - { date: "09.10.22:", desc: "Switch back to iptables-legacy due to issues on some hosts." }
   - { date: "04.10.22:", desc: "Rebase to Jammy. Upgrade to s6v3." }

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -26,63 +26,66 @@ generate_confs () {
 
 DUDE"
   for i in ${PEERS_ARRAY[@]}; do
-    if [[ "${i}" =~ ^[0-9]+$ ]]; then
-      PEER_ID="peer${i}"
+    if [[ ! "${i}" =~ ^[[:alnum:]]+$ ]]; then
+      echo "**** Peer ${i} contains non-alphanumeric characters and thus will be skipped. No config for peer ${i} will be generated. ****"
     else
-      PEER_ID="peer_${i//[^[:alnum:]_-]/}"
-    fi
-    mkdir -p /config/${PEER_ID}
-    if [ ! -f "/config/${PEER_ID}/privatekey-${PEER_ID}" ]; then
-      umask 077
-      wg genkey | tee /config/${PEER_ID}/privatekey-${PEER_ID} | wg pubkey > /config/${PEER_ID}/publickey-${PEER_ID}
-      wg genpsk > /config/${PEER_ID}/presharedkey-${PEER_ID}
-    fi
-    if [ -f "/config/${PEER_ID}/${PEER_ID}.conf" ]; then
-      CLIENT_IP=$(cat /config/${PEER_ID}/${PEER_ID}.conf | grep "Address" | awk '{print $NF}')
-      if [ -n "${ORIG_INTERFACE}" ] && [ "${INTERFACE}" != "${ORIG_INTERFACE}" ]; then
-        CLIENT_IP=$(echo "${CLIENT_IP}" | sed "s|${ORIG_INTERFACE}|${INTERFACE}|")
+      if [[ "${i}" =~ ^[0-9]+$ ]]; then
+        PEER_ID="peer${i}"
+      else
+        PEER_ID="peer_${i}"
       fi
-    else
-      for idx in {2..254}; do
-        PROPOSED_IP="${INTERFACE}.${idx}"
-        if ! grep -q -R "${PROPOSED_IP}" /config/peer*/*.conf && ([ -z "${ORIG_INTERFACE}" ] || ! grep -q -R "${ORIG_INTERFACE}.${idx}" /config/peer*/*.conf); then
-          CLIENT_IP="${PROPOSED_IP}"
-          break
+      mkdir -p /config/${PEER_ID}
+      if [ ! -f "/config/${PEER_ID}/privatekey-${PEER_ID}" ]; then
+        umask 077
+        wg genkey | tee /config/${PEER_ID}/privatekey-${PEER_ID} | wg pubkey > /config/${PEER_ID}/publickey-${PEER_ID}
+        wg genpsk > /config/${PEER_ID}/presharedkey-${PEER_ID}
+      fi
+      if [ -f "/config/${PEER_ID}/${PEER_ID}.conf" ]; then
+        CLIENT_IP=$(cat /config/${PEER_ID}/${PEER_ID}.conf | grep "Address" | awk '{print $NF}')
+        if [ -n "${ORIG_INTERFACE}" ] && [ "${INTERFACE}" != "${ORIG_INTERFACE}" ]; then
+          CLIENT_IP=$(echo "${CLIENT_IP}" | sed "s|${ORIG_INTERFACE}|${INTERFACE}|")
         fi
-      done
-    fi
-    if [ -f "/config/${PEER_ID}/presharedkey-${PEER_ID}" ]; then
-      # create peer conf with presharedkey
-      eval "`printf %s`
-      cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
+      else
+        for idx in {2..254}; do
+          PROPOSED_IP="${INTERFACE}.${idx}"
+          if ! grep -q -R "${PROPOSED_IP}" /config/peer*/*.conf 2>/dev/null && ([ -z "${ORIG_INTERFACE}" ] || ! grep -q -R "${ORIG_INTERFACE}.${idx}" /config/peer*/*.conf 2>/dev/null); then
+            CLIENT_IP="${PROPOSED_IP}"
+            break
+          fi
+        done
+      fi
+      if [ -f "/config/${PEER_ID}/presharedkey-${PEER_ID}" ]; then
+        # create peer conf with presharedkey
+        eval "`printf %s`
+        cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 `cat /config/templates/peer.conf`
 DUDE"
-      # add peer info to server conf with presharedkey
-      cat <<DUDE >> /config/wg0.conf
+        # add peer info to server conf with presharedkey
+        cat <<DUDE >> /config/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
 PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})
 DUDE
-    else
-      echo "**** Existing keys with no preshared key found for ${PEER_ID}, creating confs without preshared key for backwards compatibility ****"
-      # create peer conf without presharedkey
-      eval "`printf %s`
-      cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
+      else
+        echo "**** Existing keys with no preshared key found for ${PEER_ID}, creating confs without preshared key for backwards compatibility ****"
+        # create peer conf without presharedkey
+        eval "`printf %s`
+        cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 `cat /config/templates/peer.conf | sed '/PresharedKey/d'`
 DUDE"
-      # add peer info to server conf without presharedkey
-      cat <<DUDE >> /config/wg0.conf
+        # add peer info to server conf without presharedkey
+        cat <<DUDE >> /config/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
 DUDE
-    fi
-    SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
-    # add peer's allowedips to server conf
-    if [ -n "${!SERVER_ALLOWEDIPS}" ]; then
-      echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
-      cat <<DUDE >> /config/wg0.conf
+      fi
+      SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
+      # add peer's allowedips to server conf
+      if [ -n "${!SERVER_ALLOWEDIPS}" ]; then
+        echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
+        cat <<DUDE >> /config/wg0.conf
 AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWEDIPS}
 
 DUDE
@@ -91,14 +94,15 @@ DUDE
 AllowedIPs = ${CLIENT_IP}/32
 
 DUDE
+      fi
+      if [ -z "${LOG_CONFS}" ] || [ "${LOG_CONFS}" = "true" ]; then
+        echo "PEER ${i} QR code:"
+        qrencode -t ansiutf8 < /config/${PEER_ID}/${PEER_ID}.conf
+      else
+        echo "PEER ${i} conf and QR code png saved in /config/${PEER_ID}"
+      fi
+      qrencode -o /config/${PEER_ID}/${PEER_ID}.png < /config/${PEER_ID}/${PEER_ID}.conf
     fi
-    if [ -z "${LOG_CONFS}" ] || [ "${LOG_CONFS}" = "true" ]; then
-      echo "PEER ${i} QR code:"
-      qrencode -t ansiutf8 < /config/${PEER_ID}/${PEER_ID}.conf
-    else
-      echo "PEER ${i} conf and QR code png saved in /config/${PEER_ID}"
-    fi
-    qrencode -o /config/${PEER_ID}/${PEER_ID}.png < /config/${PEER_ID}/${PEER_ID}.conf
   done
 }
 


### PR DESCRIPTION
skip non-alnum peers and log a message instead of crashing init

due to cat to file, the diff is messed up, but the only real change is wrapping the entire for loop contents in an if block that checks alnum and skips if necessary (lines 29, 30 and 94/105)

also line 48/51 discards stderr when the folders and files don't exist