### PR TITLE
Add rootless container engine section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ Container images are configured using parameters passed at runtime (such as thos
 
 This image utilises `cap_add` or `sysctl` to work properly. This is not implemented properly in some versions of Portainer, thus this image may not work if deployed through Portainer.
 
+### Rootless Docker/Podman and SELinux unofficial support
+
+The additional parameters `--cap-add=NET_RAW`, `--security-opt label=disable` may be required on some systems like Fedora CoreOS.
+
+`--security-opt label=disable` disables SELinux labeling for the container, which allows `ip` to `module_request` wireguard if the kernel module has not been previously loaded. This is typically the case as most systems do not boot with wireguard kernel module loaded and would otherwise require a priviledged user to first `sudo modprobe wireguard` before the container could be run.
+
+`--cap-add=NET_RAW` is required on newer kernels to allow `0.0.0.0/0`, `0::0/0`. You should avoid `NET_RAW` if you do not need these routes.
+
+These parameters allow a completely unpriviledged user, without access to `sudo` or a root docker daemon, to run the container on SELinux enforcing systems without resorting to `--privileged`.
+
+Please note that this does not grant an unpriviledged user additional privileges on the host system. **This configuration is entirely unsupported and may break in a future release. No help will be provided if your system requires additional configuration not outlined in this section, any issue pertaining to running this container rootless is out of scope and invalid. Do not blindly add these parameters without understanding their purpose. This section is provided in a effort to improve host system security.**
+
 ## Environment variables from files (Docker secrets)
 
 You can set any environment variable from a file by using a special prepend `FILE__`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Create a new section in README outlining potential additional optional parameters to enable running the container in rootless container engines and SELinux enforcing systems.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
I understand rootless docker/podman and SELinux are not supported, however this image does function on such systems, like Fedora and RHEL.

There was no documentation I could find online that describes running wireguard with rootless podman that didn't require root to first `modprobe wireguard` kernel module. `ip` does issue a `module_request` to load the module without needing to use `sudo` outside of the container that will be initially blocked on SELinux enforcing systems. 

These parameters allow a completely unpriviledged user, without sudo or access to a root docker daemon, to run the container on SELinux enforcing systems.

`NET_RAW` seems to be a requirement on newer kernels and does allow client mode WG to properly setup 0.0.0.0/0 and 0::0/0 allowed IPs. This fixes the issue where some users would have to disable IPv6 or modify IPv4 allowed IP to 0.0.0.0/1. This also allows users with only an IPv4 address to have an IPv6 route.

`--security-opt label=disable` is not ideal, and I will be looking into narrowing the permission scope to only allowing `module_request`. 

Regardless, these additional parameters allowing the use of rootless docker/podman are substantially more secure than:
1. Docker daemon/Podman executed with root.
2. A system with no SELinux, or SELinux in permissive mode.
3. A user in the `sudo` or `docker` group running rootless docker/podman.
4. A completely unprivileged user not in `sudo` running any container with `--privileged`.

No additional effort is required by the maintainers to support these configurations. I think it is at least worth mentioning that this container does support these configurations unofficially with additional fine grained permission parameters rather than throwing root or `--privileged` at the issue like most documentation/blogs I've read related to wireguard and rootless container engines.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Documentation surrounding running wireguard with a rootless container engine is either outdated, uses workarounds, or promotes poor practice. This appears to be the most popular container with wireguard so it is worth adding a section denoting the additional parameters necessary to running the container in rootless environments even if it is not officially supported. 
Specifically to avoid bad configurations such as:
- running with `--privileged`, incorrectly granting more permissions than is actually required.
- Modifying or removing IPv6, IPv4 configuration when not strictly necessary. Ex 0.0.0.0/1 hack when `NET_RAW` is required.
- User manually `sudo modprobe wireguard` on each boot when `ip` requests the module anyway.
- Module blocked from automatically loading due to SELinux in enforcing mode.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fedora CoreOS VM

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
