### PR TITLE
Allow `_` in peer names

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -30,8 +30,8 @@ $(cat /config/templates/server.conf)
 
 DUDE"
   for i in "${PEERS_ARRAY[@]}"; do
-    if [[ ! "${i}" =~ ^[-_[:alnum:]]+$ ]]; then
-      echo "**** Peer ${i} contains special characters and thus will be skipped. No config for peer ${i} will be generated. ****"
+    if [[ ! "${i}" =~ ^[_[:alnum:]]+$ ]]; then
+      echo "**** Peer ${i} contains non-alphanumeric-underscore characters and thus will be skipped. No config for peer ${i} will be generated. ****"
     else
       if [[ "${i}" =~ ^[0-9]+$ ]]; then
         PEER_ID="peer${i}"

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -30,8 +30,8 @@ $(cat /config/templates/server.conf)
 
 DUDE"
   for i in "${PEERS_ARRAY[@]}"; do
-    if [[ ! "${i}" =~ ^[[:alnum:]]+$ ]]; then
-      echo "**** Peer ${i} contains non-alphanumeric characters and thus will be skipped. No config for peer ${i} will be generated. ****"
+    if [[ ! "${i}" =~ ^[-_[:alnum:]]+$ ]]; then
+      echo "**** Peer ${i} contains special characters and thus will be skipped. No config for peer ${i} will be generated. ****"
     else
       if [[ "${i}" =~ ^[0-9]+$ ]]; then
         PEER_ID="peer${i}"


### PR DESCRIPTION
Add `_` to the list of allowed characters for the peer config generator.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Underscore is commonly used as a substitute for the space character, so I thought it'd be appropriate to allow that here.

The dash character is a commonly used character in hostnames, since the use of the dash causes errors in this situation, I thought allowing the underscore character would allow the same result to be achieved: to generate a wireguard config with a name that's identical to the name of the hosts it's deployed on.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

I had just ran afoul of this checker and thought it would be a common error amongst users. Hostnames may have the dash character but that's not permissible in this situation, so I propose the `_` to be allowed in its place.

Originally I thought about also whitelisting the dash character but that caused downstream issues because the peer name string was later used as a shell variable, and the dash is not a valid character in a shell variable name.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I have tested the specific `if` statement on a local shell (GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)).
- I have built and ran an image (x86_64) with both `-` and `_` allowed and `-` caused an issue.
  - After only allowing `_`, the change worked with no issues.
- After the container had successfully generated the configs, I rebooted the container and checked if the system still works.

### Compose file spec
```yml
version: '3'

services:
  vpn:
    image: ghcr.io/thinkier/wireguard # not published to ghcr, not that you'd want to run an untrusted image anyway
    environment:
      PUID: 1000
      PGID: 1000
      PEERS: host_one,host_two
      SERVERURL: MY_VPN_DOMAIN
      INTERNAL_SUBNET: 10.6.2.0
      PEERDNS: 192.168.0.1
    cap_add:
      - NET_ADMIN
      - SYS_MODULE
    ports:
      - 51820:51820
    sysctls:
      - "net.ipv4.conf.all.src_valid_mark=1"
    volumes:
      - ./config:/config
    restart: always
```
\* lightly edited to redact private information

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
