### PR TITLE
Fix init script

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -3,8 +3,11 @@
 # shellcheck disable=SC2016,SC1091,SC2183
 
 # prepare symlinks
-rm -rf /etc/wireguard
-mkdir -p /etc/wireguard
+if [[ -d /etc/wireguard ]]; then 
+    rm -rf /etc/wireguard/*
+else
+    mkdir -p /etc/wireguard
+fi
 ln -s /config/wg0.conf /etc/wireguard/wg0.conf
 # prepare templates
 if [[ ! -f /config/templates/server.conf ]]; then


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

The container fails to start.

I am running this on latest docker on debian 11, default settings.

```
wireguard  | User UID:    1000
wireguard  | User GID:    1000
wireguard  | Uname info: Linux 30ebfb6d19e9 6.1.0-0.deb11.5-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.12-1~bpo11+1 (2023-03-05) x86_64 x86_64 x86_64 GNU/Linux
wireguard  | **** It seems the wireguard module is already active. Skipping kernel header install and module compilation. ****
wireguard  | mkdir: cannot create directory ‘/etc/wireguard’: Invalid argument
wireguard  | ln: failed to create symbolic link '/etc/wireguard/wg0.conf': No such file or directory
wireguard  | **** Server mode is selected ****
wireguard  | **** External server port is set to 51820. Make sure that port is properly forwarded to port 51820 inside this container ****
wireguard  | **** Internal subnet is set to 10.0.0.0 ****
wireguard  | **** AllowedIPs for peers 0.0.0.0/0 ****
wireguard  | **** PEERDNS var is either not set or is set to "auto", setting peer DNS to 10.0.0.1 to use wireguard docker host's DNS. ****
wireguard  | **** Server mode is selected ****
wireguard  | **** No changes to parameters. Existing configs are used. ****
wireguard  | [custom-init] No custom files found, skipping...
wireguard  | wg-quick: `/etc/wireguard/wg0.conf' does not exist
wireguard  | s6-rc: warning: unable to start service svc-wireguard: command exited 1
```

docker
```
 Server Version: 23.0.3
 Storage Driver: overlay2
 Kernel Version: 6.1.0-0.deb11.5-amd64
 Operating System: Debian GNU/Linux 11 (bullseye)
 Architecture: x86_64
```

docker-compose.yaml
```
version: '3.8'
services:
  wireguard:
    image: linuxserver/wireguard
    restart: on-failure
    container_name: wireguard
    cap_add:
      - NET_ADMIN
      - SYS_MODULE
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=America/Vancouver
      - SERVERPORT=51820
      - PEERS=macbook
      - PEERDNS=auto
      - INTERNAL_SUBNET=10.0.0.0
      - ALLOWEDIPS=0.0.0.0/0
    volumes:
      - ./config:/config
      - /lib/modules:/lib/modules
    ports:
      - 51820:51820/udp
    sysctls:
      - net.ipv4.conf.all.src_valid_mark=1
```

## Benefits of this PR and context:
- By default, the `/etc/wireguard` directory is empty, after installation of wireguard-tools.
- This PR checks if the directory exists. If yes, it removes any config files inside, else it creates a new directory. 

## How Has This Been Tested?
Yes, tested with docker 23.0.3 on debian 11 x86_64.

## Source / References:
I found a forum post by someone else who ran into the exact same issue.
https://discourse.linuxserver.io/t/wireguard-error/7409