### PR TITLE
Rebase back to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.17
+FROM ghcr.io/linuxserver/baseimage-alpine:3.18
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.17
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.18
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.06.23:** - Rebase master to Alpine 3.18 again.
 * **26.06.23:** - Revert master to Alpine 3.17, due to issue with openresolv.
 * **24.06.23:** - Rebase master to Alpine 3.18, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf).
 * **26.04.23:** - Rework branches. Swap alpine and ubuntu builds.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.06.23:", desc: "Rebase master to Alpine 3.18 again." }
   - { date: "26.06.23:", desc: "Revert master to Alpine 3.17, due to issue with openresolv." }
   - { date: "24.06.23:", desc: "Rebase master to Alpine 3.18, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf)." }
   - { date: "26.04.23:", desc: "Rework branches. Swap alpine and ubuntu builds." }

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -184,7 +184,7 @@ else
         echo "**** No client conf found. Provide your own client conf as \"/config/wg0.conf\" and restart the container. ****"
         sleep infinity
     fi
-    printf %s "${USE_COREDNS:-false}" > /run/s6/container_environment/USE_COREDNS
+    printf %s "${USE_COREDNS,,:-false}" > /run/s6/container_environment/USE_COREDNS
 fi
 
 # set up CoreDNS

--- a/root/etc/s6-overlay/s6-rc.d/svc-coredns/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-coredns/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if netstat -apn | grep -q ":53 "; then
+if netstat -apn | grep -q ":53 " && [[ -z "${USE_COREDNS}" ]]; then
     USE_COREDNS="false"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
~~Don't merge until openresolv 3.13.2-r0 is build for arm~~

~~https://pkgs.alpinelinux.org/packages?name=openresolv&branch=v3.18&repo=&arch=&maintainer=~~

Still prints `s6-rc: fatal: unable to take locks: Resource busy` but runs correctly.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
