### PR TITLE
Add support for multiple WireGuard interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ RUN \
   sed -i 's|\[\[ $proto == -4 \]\] && cmd sysctl -q net\.ipv4\.conf\.all\.src_valid_mark=1|[[ $proto == -4 ]] \&\& [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) != 1 ]] \&\& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1|' src/wg-quick/linux.bash && \
   make -C src -j$(nproc) && \
   make -C src install && \
+  rm -rf /etc/wireguard && \
+  ln -s /config/wg_confs /etc/wireguard && \
   echo "**** clean up ****" && \
   apk del --no-network build-dependencies && \
   rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,6 +44,8 @@ RUN \
   sed -i 's|\[\[ $proto == -4 \]\] && cmd sysctl -q net\.ipv4\.conf\.all\.src_valid_mark=1|[[ $proto == -4 ]] \&\& [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) != 1 ]] \&\& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1|' src/wg-quick/linux.bash && \
   make -C src -j$(nproc) && \
   make -C src install && \
+  rm -rf /etc/wireguard && \
+  ln -s /config/wg_confs /etc/wireguard && \
   echo "**** clean up ****" && \
   apk del --no-network build-dependencies && \
   rm -rf \

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ To add more peers/clients later on, you increment the `PEERS` environment variab
 
 To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker exec -it wireguard /app/show-peer 1 4 5` or `docker exec -it wireguard /app/show-peer myPC myPhone myTablet` (Keep in mind that the QR codes are also stored as PNGs in the config folder).
 
-The templates used for server and peer confs are saved under `/config/templates`. Advanced users can modify these templates and force conf generation by deleting `/config/wg0.conf` and restarting the container.
+The templates used for server and peer confs are saved under `/config/templates`. Advanced users can modify these templates and force conf generation by deleting `/config/wg_confs/wg0.conf` and restarting the container.
+
+The container managed server conf is hardcoded to `wg0.conf`. However, the users can add additional tunnel config files with `.conf` extensions into `/config/wg_confs/` and the container will attempt to start them all in alphabetical order. If any one of the tunnels fail, they will all be stopped and the default route will be deleted, requiring user intervention to fix the invalid conf and a container restart.
 
 ## Client Mode
 
-Do not set the `PEERS` environment variable. Drop your client conf into the config folder as `/config/wg0.conf` and start the container.
+Do not set the `PEERS` environment variable. Drop your client conf(s) into the config folder as `/config/wg_confs/<tunnel name>.conf` and start the container. If there are multiple tunnel configs, the container will attempt to start them all in alphabetical order. If any one of the tunnels fail, they will all be stopped and the default route will be deleted, requiring user intervention to fix the invalid conf and a container restart.
 
 If you get IPv6 related errors in the log and connection cannot be established, edit the `AllowedIPs` line in your peer/client wg0.conf to include only `0.0.0.0/0` and not `::/0`; and restart the container.
 
@@ -330,6 +332,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.10.23:** - **Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`.
 * **28.06.23:** - Rebase master to Alpine 3.18 again.
 * **26.06.23:** - Revert master to Alpine 3.17, due to issue with openresolv.
 * **24.06.23:** - Rebase master to Alpine 3.18, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf).

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,11 +78,13 @@ app_setup_block: |
 
   To display the QR codes of active peers again, you can use the following command and list the peer numbers as arguments: `docker exec -it wireguard /app/show-peer 1 4 5` or `docker exec -it wireguard /app/show-peer myPC myPhone myTablet` (Keep in mind that the QR codes are also stored as PNGs in the config folder).
 
-  The templates used for server and peer confs are saved under `/config/templates`. Advanced users can modify these templates and force conf generation by deleting `/config/wg0.conf` and restarting the container.
+  The templates used for server and peer confs are saved under `/config/templates`. Advanced users can modify these templates and force conf generation by deleting `/config/wg_confs/wg0.conf` and restarting the container.
+
+  The container managed server conf is hardcoded to `wg0.conf`. However, the users can add additional tunnel config files with `.conf` extensions into `/config/wg_confs/` and the container will attempt to start them all in alphabetical order. If any one of the tunnels fail, they will all be stopped and the default route will be deleted, requiring user intervention to fix the invalid conf and a container restart.
 
   ## Client Mode
 
-  Do not set the `PEERS` environment variable. Drop your client conf into the config folder as `/config/wg0.conf` and start the container.
+  Do not set the `PEERS` environment variable. Drop your client conf(s) into the config folder as `/config/wg_confs/<tunnel name>.conf` and start the container. If there are multiple tunnel configs, the container will attempt to start them all in alphabetical order. If any one of the tunnels fail, they will all be stopped and the default route will be deleted, requiring user intervention to fix the invalid conf and a container restart.
 
   If you get IPv6 related errors in the log and connection cannot be established, edit the `AllowedIPs` line in your peer/client wg0.conf to include only `0.0.0.0/0` and not `::/0`; and restart the container.
 
@@ -126,6 +128,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "03.10.23:", desc: "**Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`." }
   - { date: "28.06.23:", desc: "Rebase master to Alpine 3.18 again." }
   - { date: "26.06.23:", desc: "Revert master to Alpine 3.17, due to issue with openresolv." }
   - { date: "24.06.23:", desc: "Rebase master to Alpine 3.18, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf)." }

--- a/root/app/show-peer
+++ b/root/app/show-peer
@@ -13,7 +13,7 @@ for i in "$@"; do
     PEER_ID="peer_${i//[^[:alnum:]_-]/}"
   fi
 
-  if grep -q "# ${PEER_ID}" /config/wg0.conf; then
+  if grep -q "# ${PEER_ID}" /config/wg_confs/wg0.conf; then
     echo "PEER ${i} QR code:"
     qrencode -t ansiutf8 < /config/${PEER_ID}/${PEER_ID}.conf
   else

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -2,10 +2,6 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2016,SC1091,SC2183
 
-# prepare symlinks
-rm -rf /etc/wireguard
-mkdir -p /etc/wireguard
-ln -s /config/wg0.conf /etc/wireguard/wg0.conf
 # prepare templates
 if [[ ! -f /config/templates/server.conf ]]; then
     cp /defaults/server.conf /config/templates/server.conf
@@ -180,10 +176,6 @@ if [[ -n "$PEERS" ]]; then
     fi
 else
     echo "**** Client mode selected. ****"
-    if [[ ! -f /config/wg0.conf ]]; then
-        echo "**** No client conf found. Provide your own client conf as \"/config/wg0.conf\" and restart the container. ****"
-        sleep infinity
-    fi
     USE_COREDNS="${USE_COREDNS,,}"
     printf %s "${USE_COREDNS:-false}" > /run/s6/container_environment/USE_COREDNS
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -2,6 +2,15 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2016,SC1091,SC2183
 
+mkdir -p /config/wg_confs
+
+# migration to subfolder for wg confs
+if [[ -z "$(ls -A /config/wg_confs)" ]] && [[ -f /config/wg0.conf ]]; then
+    echo "**** Performing migration to new folder structure for confs. Please see the image changelog 2023-10-03 entry for more details. ****"
+    cp /config/wg0.conf /config/wg_confs/wg0.conf
+    rm -rf /config/wg0.conf || :
+fi
+
 # prepare templates
 if [[ ! -f /config/templates/server.conf ]]; then
     cp /defaults/server.conf /config/templates/server.conf
@@ -21,7 +30,7 @@ generate_confs () {
         wg genkey | tee /config/server/privatekey-server | wg pubkey > /config/server/publickey-server
     fi
     eval "$(printf %s)
-    cat <<DUDE > /config/wg0.conf
+    cat <<DUDE > /config/wg_confs/wg0.conf
 $(cat /config/templates/server.conf)
 
 DUDE"
@@ -61,7 +70,7 @@ DUDE"
 $(cat /config/templates/peer.conf)
 DUDE"
         # add peer info to server conf with presharedkey
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat "/config/${PEER_ID}/publickey-${PEER_ID}")
@@ -75,7 +84,7 @@ DUDE
 $(sed '/PresharedKey/d' "/config/templates/peer.conf")
 DUDE"
         # add peer info to server conf without presharedkey
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat "/config/${PEER_ID}/publickey-${PEER_ID}")
@@ -85,22 +94,22 @@ DUDE
       # add peer's allowedips to server conf
       if [[ -n "${!SERVER_ALLOWEDIPS}" ]]; then
         echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWEDIPS}
 DUDE
       else
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 AllowedIPs = ${CLIENT_IP}/32
 DUDE
       fi
       # add PersistentKeepalive if the peer is specified
       if [[ -n "${PERSISTENTKEEPALIVE_PEERS_ARRAY}" ]] && ([[ "${PERSISTENTKEEPALIVE_PEERS_ARRAY[0]}" = "all" ]] || printf '%s\0' "${PERSISTENTKEEPALIVE_PEERS_ARRAY[@]}" | grep -Fxqz -- "${i}"); then
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 PersistentKeepalive = 25
 
 DUDE
       else
-        cat <<DUDE >> /config/wg0.conf
+        cat <<DUDE >> /config/wg_confs/wg0.conf
 
 DUDE
       fi
@@ -157,7 +166,7 @@ if [[ -n "$PEERS" ]]; then
     else
         echo "**** Peer DNS servers will be set to $PEERDNS ****"
     fi
-    if [[ ! -f /config/wg0.conf ]]; then
+    if [[ ! -f /config/wg_confs/wg0.conf ]]; then
         echo "**** No wg0.conf found (maybe an initial install), generating 1 server and ${PEERS} peer/client confs ****"
         generate_confs
         save_vars

--- a/root/etc/s6-overlay/s6-rc.d/svc-wireguard/finish
+++ b/root/etc/s6-overlay/s6-rc.d/svc-wireguard/finish
@@ -1,4 +1,12 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-wg-quick down wg0
+if [[ -f "/app/activeconfs" ]]; then
+    . /app/activeconfs
+    for tunnel in $(printf '%s\n' "${WG_CONFS[@]}" | tac | tr '\n' ' '; echo); do
+        echo "**** Disabling tunnel ${tunnel} ****"
+        wg-quick down "${tunnel}" || :
+    done
+    echo "**** All tunnels are down ****"
+    rm -rf /app/activeconfs
+fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
@@ -22,7 +22,7 @@ fi
 unset FAILED
 for tunnel in ${WG_CONFS[@]}; do
     echo "**** Activating tunnel ${tunnel} ****"
-    wgquick up "${tunnel}" || ( echo FAILED="${tunnel}" && break)
+    wg-quick up "${tunnel}" || ( echo FAILED="${tunnel}" && break)
 done
 
 if [[ -z "${FAILED}" ]]; then
@@ -35,7 +35,7 @@ else
             break
         else
             echo "**** Disabling tunnel ${tunnel} ****"
-            wgquick down "${tunnel}" || :
+            wg-quick down "${tunnel}" || :
         fi
     done
     ip route del default

--- a/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
@@ -1,4 +1,43 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-wg-quick up wg0
+unset WG_CONFS
+rm -rf /app/activeconfs
+# Enumerate interfaces
+for wgconf in $(ls /config/*.conf); do
+    if grep -q "\[Interface\]" "${wgconf}"; then
+        echo "**** Found WG conf ${wgconf}, adding to list ****"
+        WG_CONFS+=("${wgconf}")
+    else
+        echo "**** Found WG conf ${wgconf}, but it doesn't seem to be valid, skipping. ****"
+    fi
+done
+
+if [[ -z "${WG_CONFS}" ]]; then
+    echo "**** No valid tunnel config found. Please create a valid config and restart the container ****"
+    ip route del default
+    exit 0
+fi
+
+unset FAILED
+for tunnel in ${WG_CONFS[@]}; do
+    echo "**** Activating tunnel ${tunnel} ****"
+    wgquick up "${tunnel}" || ( echo FAILED="${tunnel}" && break)
+done
+
+if [[ -z "${FAILED}" ]]; then
+    declare -p WG_CONFS > /app/activeconfs
+    echo "**** All tunnels are now active ****"
+else
+    echo "**** Tunnel ${FAILED} failed, will stop all others! ****"
+    for tunnel in ${WG_CONFS[@]}; do
+        if [[ "${tunnel}" = "${FAILED}" ]]; then
+            break
+        else
+            echo "**** Disabling tunnel ${tunnel} ****"
+            wgquick down "${tunnel}" || :
+        fi
+    done
+    ip route del default
+    echo "**** All tunnels are now down. Please fix the tunnel config ${FAILED} and restart the container ****"
+fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
@@ -4,7 +4,7 @@
 unset WG_CONFS
 rm -rf /app/activeconfs
 # Enumerate interfaces
-for wgconf in $(ls /config/*.conf); do
+for wgconf in $(ls /config/wg_confs/*.conf); do
     if grep -q "\[Interface\]" "${wgconf}"; then
         echo "**** Found WG conf ${wgconf}, adding to list ****"
         WG_CONFS+=("${wgconf}")

--- a/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-wireguard/run
@@ -22,7 +22,10 @@ fi
 unset FAILED
 for tunnel in ${WG_CONFS[@]}; do
     echo "**** Activating tunnel ${tunnel} ****"
-    wg-quick up "${tunnel}" || ( echo FAILED="${tunnel}" && break)
+    if ! wg-quick up "${tunnel}"; then
+      FAILED="${tunnel}"
+      break
+    fi
 done
 
 if [[ -z "${FAILED}" ]]; then


### PR DESCRIPTION
- Move WireGuard configs to subfolder `/config/wg_confs`
- Attempt to start all `/config/wg_confs/*.conf` in alphabetical order, if any one fails, stop all and delete default route to block network until restart
- Attempt one time migration of active `/config/wg0.conf` to `/config/wg_conf/wg0.conf` to prevent breaking existing installs
