### PR TITLE
use iptables-legacy on alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     grep \
     iproute2 \
     iptables \
+    iptables-legacy \
     ip6tables \
     iputils \
     libcap-utils \
@@ -29,6 +30,13 @@ RUN \
     net-tools \
     openresolv && \
   echo "wireguard" >> /etc/modules && \
+  cd /sbin && \
+  for i in ! !-save !-restore; do \
+    rm -rf iptables$(echo "${i}" | cut -c2-) && \
+    rm -rf ip6tables$(echo "${i}" | cut -c2-) && \
+    ln -s iptables-legacy$(echo "${i}" | cut -c2-) iptables$(echo "${i}" | cut -c2-) && \
+    ln -s ip6tables-legacy$(echo "${i}" | cut -c2-) ip6tables$(echo "${i}" | cut -c2-); \
+  done && \
   echo "**** install wireguard-tools ****" && \
   if [ -z ${WIREGUARD_RELEASE+x} ]; then \
     WIREGUARD_RELEASE=$(curl -sX GET "https://api.github.com/repos/WireGuard/wireguard-tools/tags" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,6 +22,7 @@ RUN \
     grep \
     iproute2 \
     iptables \
+    iptables-legacy \
     ip6tables \
     iputils \
     libcap-utils \
@@ -29,6 +30,13 @@ RUN \
     net-tools \
     openresolv && \
   echo "wireguard" >> /etc/modules && \
+  cd /sbin && \
+  for i in ! !-save !-restore; do \
+    rm -rf iptables$(echo "${i}" | cut -c2-) && \
+    rm -rf ip6tables$(echo "${i}" | cut -c2-) && \
+    ln -s iptables-legacy$(echo "${i}" | cut -c2-) iptables$(echo "${i}" | cut -c2-) && \
+    ln -s ip6tables-legacy$(echo "${i}" | cut -c2-) ip6tables$(echo "${i}" | cut -c2-); \
+  done && \
   echo "**** install wireguard-tools ****" && \
   if [ -z ${WIREGUARD_RELEASE+x} ]; then \
     WIREGUARD_RELEASE=$(curl -sX GET "https://api.github.com/repos/WireGuard/wireguard-tools/tags" \

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **10.03.24:** - USe iptables-legacy on Alpine 3.19.
+* **10.03.24:** - Use iptables-legacy on Alpine 3.19.
 * **05.03.24:** - Rebase master to Alpine 3.19.
 * **03.10.23:** - **Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`.
 * **28.06.23:** - Rebase master to Alpine 3.18 again.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.03.24:** - USe iptables-legacy on Alpine 3.19.
 * **05.03.24:** - Rebase master to Alpine 3.19.
 * **03.10.23:** - **Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`.
 * **28.06.23:** - Rebase master to Alpine 3.18 again.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -128,6 +128,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.03.24:", desc: "USe iptables-legacy on Alpine 3.19." }
   - { date: "05.03.24:", desc: "Rebase master to Alpine 3.19." }
   - { date: "03.10.23:", desc: "**Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`." }
   - { date: "28.06.23:", desc: "Rebase master to Alpine 3.18 again." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -128,7 +128,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "10.03.24:", desc: "USe iptables-legacy on Alpine 3.19." }
+  - { date: "10.03.24:", desc: "Use iptables-legacy on Alpine 3.19." }
   - { date: "05.03.24:", desc: "Rebase master to Alpine 3.19." }
   - { date: "03.10.23:", desc: "**Potentially Breaking Change:** Support for multiple interfaces added. Wireguard confs moved to `/config/wg_confs/`. Any file with a `.conf` extension in that folder will be treated as a live tunnel config and will be attempted to start. If any of the tunnels fail, all tunnels will be stopped. Tunnels are started in alphabetical order. Managed server conf will continue to be hardcoded to `wg0.conf`." }
   - { date: "28.06.23:", desc: "Rebase master to Alpine 3.18 again." }


### PR DESCRIPTION
Move symlinks for `iptables`, `iptables-save`, `iptables-restore` and their ipv6 counterparts to `iptables-legacy` and `ip6tables-legacy`, respectively.

closes #325 