### PR TITLE
Template peer info appended to the server config

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -130,6 +130,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.07.24:", desc: "Peer info that is appended to the server config is now templated." }
   - { date: "24.05.24:", desc: "Rebase to Alpine 3.20, install wireguard-tools from Alpine repo." }
   - { date: "10.03.24:", desc: "Use iptables-legacy on Alpine 3.19." }
   - { date: "05.03.24:", desc: "Rebase master to Alpine 3.19." }

--- a/root/defaults/server-peer.conf
+++ b/root/defaults/server-peer.conf
@@ -1,0 +1,5 @@
+[Peer]
+# friendly_name = ${PEER_ID}
+PublicKey = $(cat "/config/${PEER_ID}/publickey-${PEER_ID}")
+$([[ -f "/config/${PEER_ID}/presharedkey-${PEER_ID}" ]] && echo "PresharedKey = $(cat /config/${PEER_ID}/presharedkey-${PEER_ID})" || echo)
+$([[ -n "${!SERVER_ALLOWEDIPS}" ]] && echo "AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWED_IPS}" || echo "AllowedIPs = ${CLIENT_IP}/32")

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -18,6 +18,9 @@ fi
 if [[ ! -f /config/templates/peer.conf ]]; then
     cp /defaults/peer.conf /config/templates/peer.conf
 fi
+if [[ ! -f /config/templates/server-peer.conf ]]; then
+    cp /defaults/server-peer.conf /config/templates/server-peer.conf
+fi
 # add preshared key to user templates (backwards compatibility)
 if ! grep -q 'PresharedKey' /config/templates/peer.conf; then
     sed -i 's|^Endpoint|PresharedKey = \$\(cat /config/\${PEER_ID}/presharedkey-\${PEER_ID}\)\nEndpoint|' /config/templates/peer.conf
@@ -69,13 +72,6 @@ DUDE"
                 cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 $(cat /config/templates/peer.conf)
 DUDE"
-                # add peer info to server conf with presharedkey
-                cat <<DUDE >> /config/wg_confs/wg0.conf
-[Peer]
-# ${PEER_ID}
-PublicKey = $(cat "/config/${PEER_ID}/publickey-${PEER_ID}")
-PresharedKey = $(cat "/config/${PEER_ID}/presharedkey-${PEER_ID}")
-DUDE
             else
                 echo "**** Existing keys with no preshared key found for ${PEER_ID}, creating confs without preshared key for backwards compatibility ****"
                 # create peer conf without presharedkey
@@ -83,25 +79,16 @@ DUDE
                 cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
 $(sed '/PresharedKey/d' "/config/templates/peer.conf")
 DUDE"
-                # add peer info to server conf without presharedkey
-                cat <<DUDE >> /config/wg_confs/wg0.conf
-[Peer]
-# ${PEER_ID}
-PublicKey = $(cat "/config/${PEER_ID}/publickey-${PEER_ID}")
-DUDE
             fi
             SERVER_ALLOWEDIPS=SERVER_ALLOWEDIPS_PEER_${i}
-            # add peer's allowedips to server conf
             if [[ -n "${!SERVER_ALLOWEDIPS}" ]]; then
                 echo "Adding ${!SERVER_ALLOWEDIPS} to wg0.conf's AllowedIPs for peer ${i}"
-                cat <<DUDE >> /config/wg_confs/wg0.conf
-AllowedIPs = ${CLIENT_IP}/32,${!SERVER_ALLOWEDIPS}
-DUDE
-            else
-                cat <<DUDE >> /config/wg_confs/wg0.conf
-AllowedIPs = ${CLIENT_IP}/32
-DUDE
             fi
+            # add peer info to server conf
+            eval "$(printf %s)
+            cat <<DUDE >> /config/wg_confs/wg0.conf
+$(cat /config/templates/server-peer.conf)
+DUDE"
             # add PersistentKeepalive if the peer is specified
             if [[ -n "${PERSISTENTKEEPALIVE_PEERS_ARRAY}" ]] && ([[ "${PERSISTENTKEEPALIVE_PEERS_ARRAY[0]}" = "all" ]] || printf '%s\0' "${PERSISTENTKEEPALIVE_PEERS_ARRAY[@]}" | grep -Fxqz -- "${i}"); then
                 cat <<DUDE >> /config/wg_confs/wg0.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

`[Peer]` blocks inside `wg0.conf` used to be hardcoded. But there are very specific usecases where this might not be desirable. So, these blocks are now templated.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Closes #335.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running this command produced equivalent configuration files before and after the changes made, except the `friendly_name = ` line:

```bash
docker run -d \
  --name=wireguard \
  --cap-add=NET_ADMIN \
  --cap-add=SYS_MODULE \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/Moscow \
  -e SERVERPORT=51820 \
  -e PEERS=TheA,TheB,TheC \
  -e INTERNAL_SUBNET=10.13.13.0 `#optional` \
  -e ALLOWEDIPS=0.0.0.0/0 `#optional` \
  -e PERSISTENTKEEPALIVE_PEERS=TheC \
  -e LOG_CONFS=true `#optional` \
  -p 51820:51820/udp \
  -v wg-thing:/config \
  -v /lib/modules:/lib/modules `#optional` \
  --sysctl="net.ipv4.conf.all.src_valid_mark=1" \
  --restart unless-stopped \
  lscr.io/linuxserver/wireguard:latest
```

Here's a diff with some dummy keys:

```diff
4c4
< PrivateKey = SKO8MxSnzOCPiNoq/HIvyATfnksEINWKXk4IC4Kp3mk=
---
> PrivateKey = iIh6dFt4IJ3DwKp8GvZh2+DUWwUWp2IJD/sYAART/ks=
9,11c9,11
< # peer_TheA
< PublicKey = dS3HgHgvrFmjKlPlcB8juERrTHu2WlL5kSipLODgaDk=
< PresharedKey = zRC7UcvqIWIIsVchmtsSAYC4Qa1G+OPLXdBMHUUulS0=
---
> # friendly_name = peer_TheA
> PublicKey = 3+zJGVJp+Pmtw5aKXg5hH00X79vmV7FV7yoioB3mvE0=
> PresharedKey = OeE/fo4SI4KYwrSATVDViba50If7t635aZFcTeCWBMk=
15,17c15,17
< # peer_TheB
< PublicKey = mUEENNG9zXmq8RO4qdHkcbkO0h2mSYT1ewbyOebQVgQ=
< PresharedKey = svDHI0L1NpVYwrpsNguxJW0+bqNzXFMCp/fCd6QBD2s=
---
> # friendly_name = peer_TheB
> PublicKey = B13Es6dp2QtcNlUi5yxKZQHCkl7n0rMzgosBKCKyBXE=
> PresharedKey = mOrHbrB4NdoOjgZIxXy/UmwBhtK1kfen6lXdIesJgSk=
21,23c21,23
< # peer_TheC
< PublicKey = NgrQMdiotUWc3KP9xgTHur8KEoCvILTq0mIO78e8fkA=
< PresharedKey = /a7lxaQFOGiI+sC72dIghwHsSAfpCdc/btTweM6LK20=
---
> # friendly_name = peer_TheC
> PublicKey = 5SF4exknx+na5gPpGf9KAkgVy806npfRmKob9eg4wBE=
> PresharedKey = yDoiF2IVwCZRMNqQcudjDw2nwdKfKMRjrsM1qdlwczE=
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

See: #335.