### PR TITLE
fix: update iptables symlinks path for Alpine 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     openresolv \
     wireguard-tools==${WIREGUARD_RELEASE} && \
   echo "wireguard" >> /etc/modules && \
-  cd /sbin && \
+  cd /usr/sbin && \
   for i in ! !-save !-restore; do \
     rm -rf iptables$(echo "${i}" | cut -c2-) && \
     rm -rf ip6tables$(echo "${i}" | cut -c2-) && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -31,7 +31,7 @@ RUN \
     openresolv \
     wireguard-tools==${WIREGUARD_RELEASE} && \
   echo "wireguard" >> /etc/modules && \
-  cd /sbin && \
+  cd /usr/sbin && \
   for i in ! !-save !-restore; do \
     rm -rf iptables$(echo "${i}" | cut -c2-) && \
     rm -rf ip6tables$(echo "${i}" | cut -c2-) && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Alpine Linux 3.21 moved iptables binaries from `/sbin` to `/usr/sbin`, which breaks the symlinks we create during the image build. The fix updates the symlink creation path to match this change.
This ensures iptables-legacy is properly set up, fixing the iptables failure we were seeing on some systems where nftables support was limited.
The change is minimal but critical for systems that rely on legacy iptables support (like Synology NAS).

## Benefits of this PR and context:
Fix #375 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on macOS 15.2 and DSM 7.2.2

## Source / References:
Issue #375 
