### PR TITLE
Add ipset package to Docker images for custom routing support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   echo "**** install dependencies ****" && \
   apk add --no-cache \
     bc \
+    ipset \
     coredns \
     grep \
     iproute2 \
@@ -29,7 +30,7 @@ RUN \
     net-tools \
     nftables \
     openresolv \
-    wireguard-tools==${WIREGUARD_RELEASE} && \
+  wireguard-tools==${WIREGUARD_RELEASE} && \
   echo "wireguard" >> /etc/modules && \
   sed -i 's|\[\[ $proto == -4 \]\] && cmd sysctl -q net\.ipv4\.conf\.all\.src_valid_mark=1|[[ $proto == -4 ]] \&\& [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) != 1 ]] \&\& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1|' /usr/bin/wg-quick && \
   rm -rf /etc/wireguard && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN \
   echo "**** install dependencies ****" && \
   apk add --no-cache \
     bc \
+    ipset \
     coredns \
     grep \
     iproute2 \
@@ -29,7 +30,7 @@ RUN \
     net-tools \
     nftables \
     openresolv \
-    wireguard-tools==${WIREGUARD_RELEASE} && \
+  wireguard-tools==${WIREGUARD_RELEASE} && \
   echo "wireguard" >> /etc/modules && \
   sed -i 's|\[\[ $proto == -4 \]\] && cmd sysctl -q net\.ipv4\.conf\.all\.src_valid_mark=1|[[ $proto == -4 ]] \&\& [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) != 1 ]] \&\& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1|' /usr/bin/wg-quick && \
   rm -rf /etc/wireguard && \


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wireguard/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

**Description:**
Added the ipset package to both [Dockerfile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Dockerfile.aarch64](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This change is required for custom routing setups in my use case.

**Benefits of this PR and context:**
ipset enables advanced rule-based routing and network management inside the container, which is necessary for custom routing scenarios.

**How Has This Been Tested?**
The images were built locally and verified to include ipset. Custom routing functionality was tested and confirmed to work as expected.

**Source / References:**
https://linux.die.net/man/8/ipset
