### PR TITLE
rebase to 3.23

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -29,7 +29,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of master branch. To disable this trigger, add \`wireguard_master\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+          EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.23/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
             && awk '/^P:'"wireguard-tools"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
           echo "Type is \`alpine_repo\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^wireguard_master_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
@@ -107,7 +107,7 @@ jobs:
           if [ "${EXT_RELEASE_SANITIZED}" == "${IMAGE_VERSION}" ]; then
             echo "Sanitized version \`${EXT_RELEASE_SANITIZED}\` already pushed, exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
-          elif [[ $(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/main/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"wireguard-tools"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]; then
+          elif [[ $(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.23/main/aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"wireguard-tools"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]; then
             echo "New version \`${EXT_RELEASE}\` found; but not all arch repos updated yet; exiting" >> $GITHUB_STEP_SUMMARY
             FAILURE_REASON="New version ${EXT_RELEASE} for wireguard tag latest is detected, however not all arch repos are updated yet. Will try again later."
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:3.22
+FROM ghcr.io/linuxserver/baseimage-alpine:3.23
 
 # set version label
 ARG BUILD_DATE
@@ -10,8 +10,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thespad"
 
 RUN \
-  if [ -z ${WIREGUARD_RELEASE+x} ]; then \
-  WIREGUARD_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+  if [ -z "${WIREGUARD_RELEASE+x}" ]; then \
+  WIREGUARD_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.23/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:wireguard-tools$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   echo "**** install dependencies ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.22
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.23
 
 # set version label
 ARG BUILD_DATE
@@ -10,8 +10,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thespad"
 
 RUN \
-  if [ -z ${WIREGUARD_RELEASE+x} ]; then \
-  WIREGUARD_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+  if [ -z "${WIREGUARD_RELEASE+x}" ]; then \
+  WIREGUARD_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.23/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
     && awk '/^P:wireguard-tools$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   echo "**** install dependencies ****" && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,14 +20,14 @@ pipeline {
     QUAYIO_API_TOKEN=credentials('quayio-repo-api-token')
     GIT_SIGNING_KEY=credentials('484fbca6-9a4f-455e-b9e3-97ac98785f5f')
     CONTAINER_NAME = 'wireguard'
-    BUILD_VERSION_ARG = 'WIREGUARD_VERSION'
+    BUILD_VERSION_ARG = 'WIREGUARD_RELEASE'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-wireguard'
     DOCKERHUB_IMAGE = 'linuxserver/wireguard'
     DEV_DOCKERHUB_IMAGE = 'lsiodev/wireguard'
     PR_DOCKERHUB_IMAGE = 'lspipepr/wireguard'
     DIST_IMAGE = 'alpine'
-    DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.22/main/'
+    DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.23/main/'
     DIST_REPO_PACKAGES = 'wireguard-tools'
     MULTIARCH='true'
     CI='false'

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.01.26:** - Rebase to Alpine 3.23 again as openresolv alpine 3.23 package has now been updated.
 * **22.01.26:** - Revert to Alpine 3.22 due to resolvconf bug.
 * **04.01.26:** - Rebase to Alpine 3.23.
 * **15.07.25:** - Rebase to Alpine 3.22. Remove iptables-legacy shim.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -8,14 +8,14 @@ release_tag: latest
 ls_branch: master
 repo_vars:
   - CONTAINER_NAME = 'wireguard'
-  - BUILD_VERSION_ARG = 'WIREGUARD_VERSION'
+  - BUILD_VERSION_ARG = 'WIREGUARD_RELEASE'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-wireguard'
   - DOCKERHUB_IMAGE = 'linuxserver/wireguard'
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/wireguard'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/wireguard'
   - DIST_IMAGE = 'alpine'
-  - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.22/main/'
+  - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.23/main/'
   - DIST_REPO_PACKAGES = 'wireguard-tools'
   - MULTIARCH='true'
   - CI='false'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -158,6 +158,7 @@ init_diagram: |
   "wireguard:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "24.01.26:", desc: "Rebase to Alpine 3.23 again as openresolv alpine 3.23 package has now been updated."}
   - {date: "22.01.26:", desc: "Revert to Alpine 3.22 due to resolvconf bug."}
   - {date: "04.01.26:", desc: "Rebase to Alpine 3.23."}
   - {date: "15.07.25:", desc: "Rebase to Alpine 3.22. Remove iptables-legacy shim."}

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -194,6 +194,10 @@ if [[ ! -f /config/coredns/Corefile ]]; then
     cp /defaults/Corefile /config/coredns/Corefile
 fi
 
+# let openresolv take control of resolv.conf
+resolvconf -a control 2>/dev/null < /etc/resolv.conf
+resolvconf -u
+
 # permissions
 lsiown -R abc:abc \
     /config


### PR DESCRIPTION
~~testing locally~~

Tested locally with 2 wireguard containers on 2 different VPSes:
- Set first one up with `PEER=1`, `PEERDNS=auto`, `INTERNAL_SUBNET=10.13.18.0` and `URL=mydomain.duckdns.org`
- Set the second one up with no env vars and the conf from first server dropped in (contains `DNS = 10.13.18.1`)
- Started the second container, it connects to the first via duckdns domain:
  - `wg show` on the first shows the handshake
  - `wg show` on the second shows the first one's IP in endpoint (correct url resolution)
  - `curl icanhzip.com` on the second returns the first one's IP
  - resolv.conf contains the header `# Generated by resolvconf` and `nameserver 10.13.18.1`
  - Exec'ed in and did `wg_quick down wg1`, resolv.conf contents reverted to docker default with my host's search domains
- Then removed the conf from the second and restarted with an invalid conf, resolv.conf was docker's original with my search domains, but with the header added `# Generated by resolvconf`

PS.
I also noticed that the init script fails with a confusing message if no wg conf is supplied:
```
**** Found WG conf /config/wg_confs/*.conf, but it doesn't seem to be valid, skipping. ****
**** No valid tunnel config found. Please create a valid config and restart the container ****
```
We should probably check for that condition and log a message, but that can be in a different PR.