### PR TITLE
Add internal port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
 | `-e SERVERURL=wireguard.domain.com` | External IP or domain name for docker host. Used in server mode. If set to `auto`, the container will try to determine and set the external IP automatically |
 | `-e SERVERPORT=51820` | External port for docker host. Used in server mode. |
+| `-e INTERNALPORT=51820` | Internal port for docker host. Used in server mode. |
 | `-e PEERS=1` | Number of peers to create confs for. Required for server mode. Can also be a list of names: `myPC,myPhone,myTablet` (alphanumeric only) |
 | `-e PEERDNS=auto` | DNS server set in peer/client configs (can be set as `8.8.8.8`). Used in server mode. Defaults to `auto`, which uses wireguard docker host's DNS via included CoreDNS forward. |
 | `-e INTERNAL_SUBNET=10.13.13.0` | Internal subnet for the wireguard and server and peers (only change if it clashes). Used in server mode. |

--- a/root/defaults/server.conf
+++ b/root/defaults/server.conf
@@ -1,6 +1,6 @@
 [Interface]
 Address = ${INTERFACE}.1
-ListenPort = 51820
+ListenPort = ${INTERNALPORT}
 PrivateKey = $(cat /config/server/privatekey-server)
 PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth+ -j MASQUERADE
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth+ -j MASQUERADE

--- a/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
@@ -128,6 +128,7 @@ save_vars () {
     cat <<DUDE > /config/.donoteditthisfile
 ORIG_SERVERURL="$SERVERURL"
 ORIG_SERVERPORT="$SERVERPORT"
+ORIG_INTERNALPORT="$INTERNALPORT"
 ORIG_PEERDNS="$PEERDNS"
 ORIG_PEERS="$PEERS"
 ORIG_INTERFACE="$INTERFACE"
@@ -154,7 +155,10 @@ if [[ -n "$PEERS" ]]; then
         echo "**** External server address is set to $SERVERURL ****"
     fi
     SERVERPORT=${SERVERPORT:-51820}
-    echo "**** External server port is set to ${SERVERPORT}. Make sure that port is properly forwarded to port 51820 inside this container ****"
+
+    # add the ability to change the port in wg0.conf
+    INTERNALPORT=${INTERNALPORT:-51820}
+    echo "**** External server port is set to ${SERVERPORT}. Make sure that port is properly forwarded to port ${INTERNALPORT} inside this container ****"
     INTERNAL_SUBNET=${INTERNAL_SUBNET:-10.13.13.0}
     echo "**** Internal subnet is set to $INTERNAL_SUBNET ****"
     INTERFACE=$(echo "$INTERNAL_SUBNET" | awk 'BEGIN{FS=OFS="."} NF--')
@@ -175,7 +179,7 @@ if [[ -n "$PEERS" ]]; then
         if [[ -f /config/.donoteditthisfile ]]; then
             . /config/.donoteditthisfile
         fi
-        if [[ "$SERVERURL" != "$ORIG_SERVERURL" ]] || [[ "$SERVERPORT" != "$ORIG_SERVERPORT" ]] || [[ "$PEERDNS" != "$ORIG_PEERDNS" ]] || [[ "$PEERS" != "$ORIG_PEERS" ]] || [[ "$INTERFACE" != "$ORIG_INTERFACE" ]] || [[ "$ALLOWEDIPS" != "$ORIG_ALLOWEDIPS" ]] || [[ "$PERSISTENTKEEPALIVE_PEERS" != "$ORIG_PERSISTENTKEEPALIVE_PEERS" ]]; then
+        if [[ "$SERVERURL" != "$ORIG_SERVERURL" ]] || [["$INTERNALPORT" != "$ORIG_INTERNALPORT"]] || [[ "$SERVERPORT" != "$ORIG_SERVERPORT" ]] || [[ "$PEERDNS" != "$ORIG_PEERDNS" ]] || [[ "$PEERS" != "$ORIG_PEERS" ]] || [[ "$INTERFACE" != "$ORIG_INTERFACE" ]] || [[ "$ALLOWEDIPS" != "$ORIG_ALLOWEDIPS" ]] || [[ "$PERSISTENTKEEPALIVE_PEERS" != "$ORIG_PERSISTENTKEEPALIVE_PEERS" ]]; then
             echo "**** Server related environment variables changed, regenerating 1 server and ${PEERS} peer/client confs ****"
             generate_confs
             save_vars


### PR DESCRIPTION
Hello. It is assumed that the container has a bridge type network interface. Its default internal port is 51820. If you use port forwarding, then everything works. Since this is a VPN, I would like to avoid network delays associated with the network adapter, so the host type is used as the network adapter. In this case, the wg0.conf configuration will have port 51820, not the one that was set via the SERVERPORT variable. My changes suggest using another environment variable that will help redefine the internal wireguard port.

P.S. This is my first PR, please don’t judge too harshly if possible.